### PR TITLE
use `xsel` instead of `pbcopy/pbpaste` in linux

### DIFF
--- a/config/init-clipboard.el
+++ b/config/init-clipboard.el
@@ -1,14 +1,25 @@
-(defun copy-from-osx ()
-(shell-command-to-string "pbpaste"))
 
-(defun paste-to-osx (text &optional push)
-(let ((process-connection-type nil))
-(let ((proc (start-process "pbcopy" "*Messages*" "pbcopy")))
-(process-send-string proc text)
-(process-send-eof proc))))
+(when is-mac
+    (defun paste-with-Xclipboard ()
+    (shell-command-to-string "pbpaste"))
 
-(setq interprogram-cut-function 'paste-to-osx)
-(setq interprogram-paste-function 'copy-from-osx) 
+    (defun copy-to-Xclipboard (text &optional push)
+    (let ((process-connection-type nil))
+    (let ((proc (start-process "pbcopy" "*Messages*" "pbcopy")))
+    (process-send-string proc text)
+    (process-send-eof proc)))))
 
+(unless is-mac
+    (defun paste-with-Xclipboard ()
+    (shell-command-to-string "xsel -ob"))
+
+    (defun copy-to-Xclipboard (text &optional push)
+    (let ((process-connection-type nil))
+    (let ((proc (start-process "copy_to_X" "*Messages*" "xsel" "-ib")))
+    (process-send-string proc text)
+    (process-send-eof proc)))))
+
+(setq interprogram-cut-function 'copy-to-Xclipboard)
+(setq interprogram-paste-function 'paste-with-Xclipboard)
 
 (provide 'init-clipboard)

--- a/init.el
+++ b/init.el
@@ -1,4 +1,8 @@
-(setq user-full-name "Xuehao Zhou") (setq user-mail-address "robertzhouxh@gmail.com") (setq exec-path (append exec-path '("/usr/local/bin"))) (setq exec-path (append exec-path '("/usr/bin"))) (setq load-path (cons "/usr/local/lib/gtags" load-path))
+(setq user-full-name "Jin Zhong")
+(setq user-mail-address "zhongjin616@gmail.com")
+(setq exec-path (append exec-path '("/usr/local/bin")))
+(setq exec-path (append exec-path '("/usr/bin")))
+(setq load-path (cons "/usr/local/lib/gtags" load-path))
 (setq is-mac (equal system-type 'darwin))
 
 (setenv "GOPATH" (concat (getenv "HOME") "go"))

--- a/init.el
+++ b/init.el
@@ -5,7 +5,7 @@
 (setq load-path (cons "/usr/local/lib/gtags" load-path))
 (setq is-mac (equal system-type 'darwin))
 
-(setenv "GOPATH" (concat (getenv "HOME") "/goEnv"))
+(setenv "GOPATH" (concat (getenv "HOME") "go"))
 
 ;; things that don't come from package managers
 (defvar robertzhouxh/vendor-dir (expand-file-name "vendor" user-emacs-directory))


### PR DESCRIPTION
pbcopy & pbpaste is not available by default in linux. use `xsel -ib` & `xsel -ob` instead